### PR TITLE
Should fix anti-cheat "falses" and chat gpt code

### DIFF
--- a/src/main/java/net/mirador/alwayssprint/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/net/mirador/alwayssprint/mixin/ClientPlayerEntityMixin.java
@@ -2,6 +2,7 @@ package net.mirador.alwayssprint.mixin;
 
 import com.mojang.authlib.GameProfile;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.input.Input;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.world.ClientWorld;
@@ -12,20 +13,26 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
-//Defines the targeted Mixin
+
 @Mixin(ClientPlayerEntity.class)
 public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity {
-	//Constructor matching ClientPlayerEntity
-	public ClientPlayerEntityMixin(ClientWorld world, GameProfile profile) {
-		super(world, profile);
-	}
-	//Shadowing protected client Object
-	@Shadow @Final
-	protected MinecraftClient client;
-	//Injecting at the Tail of the tickMovement() method
-	@Inject(method = "tickMovement", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
-	public void tickMovement(CallbackInfo ci) {
-		//set the Player to Sprinting if the forwardKey is pressed
-		this.setSprinting(this.client.options.forwardKey.isPressed());
-	}
+    public ClientPlayerEntityMixin(ClientWorld world, GameProfile profile) {
+        super(world, profile);
+    }
+
+    @Shadow
+    @Final
+    protected MinecraftClient client;
+
+    /**
+     * Changed injection point to HEAD to allow vanilla checks to take place
+     * after we set sprinting to true.
+     *
+     * This should allow the user to always sprint as long as the vanilla checks
+     * are passed.
+     */
+    @Inject(method = "tickMovement", at = @At("HEAD"), locals = LocalCapture.CAPTURE_FAILHARD)
+    public void tickMovement(CallbackInfo ci) {
+        this.client.options.sprintKey.setPressed(true);
+    }
 }


### PR DESCRIPTION
Changed injection point to HEAD to allow vanilla checks to take place after we set sprinting to true.
This should allow the user to always sprint as long as the vanilla checks are passed.